### PR TITLE
Improve the `TH` module

### DIFF
--- a/src/Kanren/Data/Binary.hs
+++ b/src/Kanren/Data/Binary.hs
@@ -33,37 +33,21 @@ module Kanren.Data.Binary (
 ) where
 
 import Control.DeepSeq (NFData)
-import Control.Lens (Prism, from)
 import Control.Lens.TH (makePrisms)
 import Data.Bifunctor (bimap)
 import Data.Function ((&))
-import Data.Tagged (Tagged)
 import GHC.Generics (Generic)
 
 import Kanren.Core
 import Kanren.Goal
 import Kanren.LogicalBase
 import Kanren.Match
+import Kanren.TH
 
 data Bit = O | I deriving (Eq, Show, Generic, NFData)
 instance Logical Bit
 makePrisms ''Bit
-
-_O'
-  :: Prism
-      (Tagged (o, i) Bit)
-      (Tagged (o', i) Bit)
-      (Tagged o ())
-      (Tagged o' ())
-_O' = from _Tagged . _O . _Tagged
-
-_I'
-  :: Prism
-      (Tagged (o, i) Bit)
-      (Tagged (o, i') Bit)
-      (Tagged i ())
-      (Tagged i' ())
-_I' = from _Tagged . _I . _Tagged
+makeExhaustivePrisms ''Bit
 
 type Binary = [Bit]
 

--- a/src/Kanren/Data/Binary.hs
+++ b/src/Kanren/Data/Binary.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/src/Kanren/Data/Scheme.hs
+++ b/src/Kanren/Data/Scheme.hs
@@ -15,9 +15,7 @@ module Kanren.Data.Scheme (
   evalo,
 ) where
 
-import Control.Lens (Prism, from)
 import Control.Lens.TH (makePrisms)
-import Data.Tagged (Tagged)
 import GHC.Exts (IsList, IsString (..))
 import GHC.Generics (Generic)
 import GHC.IsList (IsList (..))
@@ -26,7 +24,6 @@ import Control.DeepSeq
 import Kanren.Core
 import Kanren.Goal
 import Kanren.LogicalBase
-import Kanren.Match
 import Kanren.TH
 
 type Symbol = Atomic String
@@ -71,6 +68,8 @@ makeLogical ''SExpr
 makeLogical ''Value
 makePrisms ''LogicSExpr
 makePrisms ''LogicValue
+makeExhaustivePrisms ''LogicSExpr
+makeExhaustivePrisms ''LogicValue
 
 instance Normalizable SExpr where
   normalize f (LogicSSymbol x) = LogicSSymbol <$> normalize' f x
@@ -78,30 +77,6 @@ instance Normalizable SExpr where
   normalize f (LogicSCons car cdr) = LogicSCons <$> normalize' f car <*> normalize' f cdr
 
 deriving instance NFData LogicSExpr
-
-_LogicSSymbol'
-  :: Prism
-      (Tagged (s, n, c) LogicSExpr)
-      (Tagged (s', n, c) LogicSExpr)
-      (Tagged s (Term Symbol))
-      (Tagged s' (Term Symbol))
-_LogicSSymbol' = from _Tagged . _LogicSSymbol . _Tagged
-
-_LogicSNil'
-  :: Prism
-      (Tagged (s, n, c) LogicSExpr)
-      (Tagged (s, n', c) LogicSExpr)
-      (Tagged n ())
-      (Tagged n' ())
-_LogicSNil' = from _Tagged . _LogicSNil . _Tagged
-
-_LogicSCons'
-  :: Prism
-      (Tagged (s, n, c) LogicSExpr)
-      (Tagged (s, n, c') LogicSExpr)
-      (Tagged c (Term SExpr, Term SExpr))
-      (Tagged c' (Term SExpr, Term SExpr))
-_LogicSCons' = from _Tagged . _LogicSCons . _Tagged
 
 instance Show LogicSExpr where
   show (LogicSSymbol (Value (Atomic symbol))) = symbol

--- a/src/Kanren/Data/Scheme.hs
+++ b/src/Kanren/Data/Scheme.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedLists #-}
@@ -68,8 +67,8 @@ instance IsList SExpr where
 instance IsString SExpr where
   fromString = SSymbol . Atomic
 
-makeLogic ''SExpr
-makeLogic ''Value
+makeLogical ''SExpr
+makeLogical ''Value
 makePrisms ''LogicSExpr
 makePrisms ''LogicValue
 

--- a/src/Kanren/Example/Matche.hs
+++ b/src/Kanren/Example/Matche.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -55,7 +54,7 @@ data Nat
   | S Nat
   deriving (Show, Generic)
 
-makeLogic ''Nat
+makeLogical ''Nat
 makePrisms ''LogicNat
 
 _Z' :: Prism (Tagged (z, s) LogicNat) (Tagged (z', s) LogicNat) (Tagged z ()) (Tagged z' ())

--- a/src/Kanren/Example/Tree.hs
+++ b/src/Kanren/Example/Tree.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -16,11 +15,11 @@ import Kanren.Core
 import Kanren.Goal
 import Kanren.LogicalBase ()
 import Kanren.Match
-import Kanren.TH (makeLogic)
+import Kanren.TH
 
 data Tree a = Empty | Node a (Tree a) (Tree a)
   deriving (Show, Generic)
-makeLogic ''Tree
+makeLogical ''Tree
 makePrisms ''LogicTree
 
 treeo :: Term (Tree Int) -> Goal ()

--- a/src/Kanren/LogicalBase.hs
+++ b/src/Kanren/LogicalBase.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -68,7 +67,7 @@ import Control.DeepSeq (NFData)
 import Kanren.Core
 import Kanren.GenericLogical
 import Kanren.Match (_Tagged)
-import Kanren.TH (makeLogic)
+import Kanren.TH (makeLogical)
 
 instance Logical Int
 instance Logical Char
@@ -151,7 +150,7 @@ _LogicCons'
       (Tagged cons' (Term a', Term [a']))
 _LogicCons' = from _Tagged . _LogicCons . _Tagged
 
-makeLogic ''Maybe
+makeLogical ''Maybe
 makePrisms ''LogicMaybe
 deriving instance (Eq (Logic a)) => Eq (LogicMaybe a)
 deriving instance (Show (Logic a)) => Show (LogicMaybe a)
@@ -172,7 +171,7 @@ _LogicJust'
       (Tagged just' (Term a'))
 _LogicJust' = from _Tagged . _LogicJust . _Tagged
 
-makeLogic ''Either
+makeLogical ''Either
 makePrisms ''LogicEither
 deriving instance (Eq (Logic a), Eq (Logic b)) => Eq (LogicEither a b)
 deriving instance (Show (Logic a), Show (Logic b)) => Show (LogicEither a b)

--- a/src/Kanren/LogicalBase.hs
+++ b/src/Kanren/LogicalBase.hs
@@ -56,7 +56,6 @@ module Kanren.LogicalBase (
   _LogicRight',
 ) where
 
-import Control.Lens (from)
 import Control.Lens.TH (makePrisms)
 import Data.Void (Void)
 import GHC.Exts (IsList (..))
@@ -65,8 +64,7 @@ import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
 import Kanren.Core
 import Kanren.GenericLogical
-import Kanren.Match (ExhaustivePrism, _Tagged)
-import Kanren.TH (makeLogical)
+import Kanren.TH (makeExhaustivePrisms, makeLogical)
 
 instance Logical Int
 instance Logical Char
@@ -74,12 +72,7 @@ instance Logical Void
 
 instance Logical Bool
 makePrisms ''Bool
-
-_False' :: ExhaustivePrism Bool (false, true) (false', true) () false false'
-_False' = from _Tagged . _False . _Tagged
-
-_True' :: ExhaustivePrism Bool (false, true) (false', true) () true true'
-_True' = from _Tagged . _True . _Tagged
+makeExhaustivePrisms ''Bool
 
 instance (Logical a, Logical b) => Logical (a, b) where
   type Logic (a, b) = (Term a, Term b)
@@ -122,36 +115,16 @@ instance IsList (LogicList a) where
   toList (LogicCons x xs) = x : toList xs -- NOTE: toList for (Term [a]) is partial
 
 makePrisms ''LogicList
-
-_LogicNil' :: ExhaustivePrism (LogicList a) (nil, cons) (nil', cons) () nil nil'
-_LogicNil' = from _Tagged . _LogicNil . _Tagged
-
-_LogicCons'
-  :: ExhaustivePrism (LogicList a) (nil, cons) (nil, cons') (Term a, Term [a]) cons cons'
-_LogicCons' = from _Tagged . _LogicCons . _Tagged
+makeExhaustivePrisms ''LogicList
 
 makeLogical ''Maybe
 makePrisms ''LogicMaybe
+makeExhaustivePrisms ''LogicMaybe
 deriving instance (Eq (Logic a)) => Eq (LogicMaybe a)
 deriving instance (Show (Logic a)) => Show (LogicMaybe a)
 
-_LogicNothing'
-  :: ExhaustivePrism (LogicMaybe a) (nothing, just) (nothing', just) () nothing nothing'
-_LogicNothing' = from _Tagged . _LogicNothing . _Tagged
-
-_LogicJust'
-  :: ExhaustivePrism (LogicMaybe a) (nothing, just) (nothing, just') (Term a) just just'
-_LogicJust' = from _Tagged . _LogicJust . _Tagged
-
 makeLogical ''Either
 makePrisms ''LogicEither
+makeExhaustivePrisms ''LogicEither
 deriving instance (Eq (Logic a), Eq (Logic b)) => Eq (LogicEither a b)
 deriving instance (Show (Logic a), Show (Logic b)) => Show (LogicEither a b)
-
-_LogicLeft'
-  :: ExhaustivePrism (LogicEither a b) (left, right) (left', right) (Term a) left left'
-_LogicLeft' = from _Tagged . _LogicLeft . _Tagged
-
-_LogicRight'
-  :: ExhaustivePrism (LogicEither a b) (left, right) (left, right') (Term b) right right'
-_LogicRight' = from _Tagged . _LogicRight . _Tagged

--- a/src/Kanren/LogicalBase.hs
+++ b/src/Kanren/LogicalBase.hs
@@ -56,9 +56,8 @@ module Kanren.LogicalBase (
   _LogicRight',
 ) where
 
-import Control.Lens (Prism, from)
+import Control.Lens (from)
 import Control.Lens.TH (makePrisms)
-import Data.Tagged (Tagged)
 import Data.Void (Void)
 import GHC.Exts (IsList (..))
 import GHC.Generics (Generic)
@@ -66,7 +65,7 @@ import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
 import Kanren.Core
 import Kanren.GenericLogical
-import Kanren.Match (_Tagged)
+import Kanren.Match (ExhaustivePrism, _Tagged)
 import Kanren.TH (makeLogical)
 
 instance Logical Int
@@ -76,20 +75,10 @@ instance Logical Void
 instance Logical Bool
 makePrisms ''Bool
 
-_False'
-  :: Prism
-      (Tagged (false, true) Bool)
-      (Tagged (false', true) Bool)
-      (Tagged false ())
-      (Tagged false' ())
+_False' :: ExhaustivePrism Bool (false, true) (false', true) () false false'
 _False' = from _Tagged . _False . _Tagged
 
-_True'
-  :: Prism
-      (Tagged (false, true) Bool)
-      (Tagged (false, true') Bool)
-      (Tagged true ())
-      (Tagged true' ())
+_True' :: ExhaustivePrism Bool (false, true) (false', true) () true true'
 _True' = from _Tagged . _True . _Tagged
 
 instance (Logical a, Logical b) => Logical (a, b) where
@@ -134,20 +123,11 @@ instance IsList (LogicList a) where
 
 makePrisms ''LogicList
 
-_LogicNil'
-  :: Prism
-      (Tagged (nil, cons) (LogicList a))
-      (Tagged (nil', cons) (LogicList a))
-      (Tagged nil ())
-      (Tagged nil' ())
+_LogicNil' :: ExhaustivePrism (LogicList a) (nil, cons) (nil', cons) () nil nil'
 _LogicNil' = from _Tagged . _LogicNil . _Tagged
 
 _LogicCons'
-  :: Prism
-      (Tagged (nil, cons) (LogicList a))
-      (Tagged (nil, cons') (LogicList a'))
-      (Tagged cons (Term a, Term [a]))
-      (Tagged cons' (Term a', Term [a']))
+  :: ExhaustivePrism (LogicList a) (nil, cons) (nil, cons') (Term a, Term [a]) cons cons'
 _LogicCons' = from _Tagged . _LogicCons . _Tagged
 
 makeLogical ''Maybe
@@ -156,19 +136,11 @@ deriving instance (Eq (Logic a)) => Eq (LogicMaybe a)
 deriving instance (Show (Logic a)) => Show (LogicMaybe a)
 
 _LogicNothing'
-  :: Prism
-      (Tagged (nothing, just) (LogicMaybe a))
-      (Tagged (nothing', just) (LogicMaybe a))
-      (Tagged nothing ())
-      (Tagged nothing' ())
+  :: ExhaustivePrism (LogicMaybe a) (nothing, just) (nothing', just) () nothing nothing'
 _LogicNothing' = from _Tagged . _LogicNothing . _Tagged
 
 _LogicJust'
-  :: Prism
-      (Tagged (nothing, just) (LogicMaybe a))
-      (Tagged (nothing, just') (LogicMaybe a'))
-      (Tagged just (Term a))
-      (Tagged just' (Term a'))
+  :: ExhaustivePrism (LogicMaybe a) (nothing, just) (nothing, just') (Term a) just just'
 _LogicJust' = from _Tagged . _LogicJust . _Tagged
 
 makeLogical ''Either
@@ -177,17 +149,9 @@ deriving instance (Eq (Logic a), Eq (Logic b)) => Eq (LogicEither a b)
 deriving instance (Show (Logic a), Show (Logic b)) => Show (LogicEither a b)
 
 _LogicLeft'
-  :: Prism
-      (Tagged (left, right) (LogicEither a b))
-      (Tagged (left', right) (LogicEither a' b))
-      (Tagged left (Term a))
-      (Tagged left' (Term a'))
+  :: ExhaustivePrism (LogicEither a b) (left, right) (left', right) (Term a) left left'
 _LogicLeft' = from _Tagged . _LogicLeft . _Tagged
 
 _LogicRight'
-  :: Prism
-      (Tagged (left, right) (LogicEither a b))
-      (Tagged (left, right') (LogicEither a b'))
-      (Tagged right (Term b))
-      (Tagged right' (Term b'))
+  :: ExhaustivePrism (LogicEither a b) (left, right) (left, right') (Term b) right right'
 _LogicRight' = from _Tagged . _LogicRight . _Tagged

--- a/src/Kanren/TH.hs
+++ b/src/Kanren/TH.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- | Automatic generation of logic types.
 module Kanren.TH (
@@ -19,7 +20,7 @@ module Kanren.TH (
   makeLogicalInstances,
 ) where
 
-import Data.Char (isUpper, toUpper)
+import Data.Char (isLower, isUpper, toUpper)
 import Data.Foldable (foldl')
 import GHC.Generics (Generic)
 import Language.Haskell.TH hiding (bang)
@@ -149,7 +150,8 @@ logicName name = mkName $ case nameBase name of
   ':' : rest -> ":?" <> rest
   firstLetter : rest
     | isUpper firstLetter -> "Logic" <> rest'
-    | otherwise -> "logic" <> rest'
+    | isLower firstLetter -> "logic" <> rest'
+    | otherwise -> '?' : rest'
    where
     rest' = toUpper firstLetter : rest
 

--- a/test/Kanren/THSpec.hs
+++ b/test/Kanren/THSpec.hs
@@ -54,7 +54,7 @@ makeLogical ''Record
 makeLogical ''GADTLike
 makeLogical ''RecordGADTLike
 makeLogical ''(^)
-makeLogicType ''Newtype
+makeLogical ''Newtype
 makeLogicals [''RecursiveA, ''RecursiveB]
 
 makePrisms ''LogicConstructors

--- a/test/Kanren/THSpec.hs
+++ b/test/Kanren/THSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -41,11 +40,11 @@ data RecordGADTLike a where
 
 newtype Newtype a = Newtype {runNewtype :: (a, a)} deriving (Generic)
 
-makeLogic ''Constructors
-makeLogic ''Record
-makeLogic ''GADTLike
-makeLogic ''RecordGADTLike
-makeLogic ''Newtype
+makeLogical ''Constructors
+makeLogical ''Record
+makeLogical ''GADTLike
+makeLogical ''RecordGADTLike
+makeLogicType ''Newtype
 
 instance Arbitrary Constructors where
   arbitrary =
@@ -57,6 +56,9 @@ instance Arbitrary Constructors where
 
 ofTypeTerm :: Term a -> ()
 ofTypeTerm = const ()
+
+ofTypeLogic :: Logic a -> ()
+ofTypeLogic = const ()
 
 toConstr :: Constructors -> String
 toConstr Simple = "Simple"
@@ -74,7 +76,7 @@ spec = do
             ofTypeTerm x `seq` ofTypeTerm y
       let _g (LogicGADTLike x) = ofTypeTerm x
       let _h LogicRecordGADTLike{logicGadtSpam = x} = ofTypeTerm x
-      let _n LogicNewtype{logicRunNewtype = x} = ofTypeTerm x
+      let _n LogicNewtype{logicRunNewtype = x} = ofTypeLogic x
 
       return @IO ()
 

--- a/test/Kanren/THSpec.hs
+++ b/test/Kanren/THSpec.hs
@@ -40,11 +40,15 @@ data RecordGADTLike a where
 
 newtype Newtype a = Newtype {runNewtype :: (a, a)} deriving (Generic)
 
+data RecursiveA = RecursiveA Int RecursiveB deriving (Generic)
+data RecursiveB = RecursiveB Bool RecursiveA deriving (Generic)
+
 makeLogical ''Constructors
 makeLogical ''Record
 makeLogical ''GADTLike
 makeLogical ''RecordGADTLike
 makeLogicType ''Newtype
+makeLogicals [''RecursiveA, ''RecursiveB]
 
 instance Arbitrary Constructors where
   arbitrary =
@@ -77,6 +81,8 @@ spec = do
       let _g (LogicGADTLike x) = ofTypeTerm x
       let _h LogicRecordGADTLike{logicGadtSpam = x} = ofTypeTerm x
       let _n LogicNewtype{logicRunNewtype = x} = ofTypeLogic x
+      let _a (LogicRecursiveA x y) = ofTypeTerm x `seq` ofTypeTerm y
+      let _b (LogicRecursiveB x y) = ofTypeTerm x `seq` ofTypeTerm y
 
       return @IO ()
 


### PR DESCRIPTION
- [x] Let the user generate logic types and `Logical` instances separately;
- [x] Generate proper logic types for `newtype`s;
- [x] Generate corresponding `Logical` instances for `newtype`s;
- [x] Remove the need for the `ConstraintKinds` extension;
- [x] Support mutually exclusive types;
- [x] Support syntax like `(:*) Int Int` and ``Int `Pair` Int``;
- [x] Let the user configure derived instances for the logical type;
- [x] Generate prisms for exhaustive matching;
- [ ] Let the user configure constraints for the logical type?
- [ ] Let the user configure prefixes for logical names?

Closes #7.