### PR TITLE
set-var-val! optimization via IORefs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
             stack
             ghcid
             (haskell-language-server.override {
-              supportedGhcVersions = [ "96" ];
+              supportedGhcVersions = [ "98" ];
             })
             haskellPackages.fourmolu
           ];

--- a/src/Kanren/Example/Matche.hs
+++ b/src/Kanren/Example/Matche.hs
@@ -19,11 +19,13 @@ import Kanren.LogicalBase
 import Kanren.Match
 import Kanren.TH
 
+import Debug.Trace (trace)
+
 eithero :: (Logical a, Logical b) => Term (Either a b) -> Goal ()
 eithero =
   matche
-    & on _LogicLeft (\_ -> return ())
-    & on _LogicRight (\_ -> return ())
+    & on _LogicLeft (\_ -> trace "handle left" $ return ())
+    & on _LogicRight (\_ -> trace "handle right" $ return ())
 
 nestedo :: Term (Either (Either Int Bool) Int) -> Goal ()
 nestedo =

--- a/src/Kanren/GenericLogical.hs
+++ b/src/Kanren/GenericLogical.hs
@@ -57,7 +57,7 @@ import           Kanren.Core
 class GLogical f f' where
   gunify :: Proxy f -> f' p -> f' p -> State -> Maybe State
   gwalk :: Proxy f -> State -> f' p -> f' p
-  goccursCheck :: Proxy f -> VarId b -> f' p -> State -> Bool
+  goccursCheck :: Proxy f -> Var b -> f' p -> State -> Bool
   ginject :: f p -> f' p
   gextract :: f' p -> Maybe (f p)
 
@@ -142,7 +142,7 @@ genericWalk k term = to (gwalk (Proxy @(Rep a)) k (from term))
 genericOccursCheck
   :: forall a b
    . (Generic (Logic a), GLogical (Rep a) (Rep (Logic a)))
-  => VarId b
+  => Var b
   -> Logic a
   -> State
   -> Bool

--- a/src/Kanren/Goal.hs
+++ b/src/Kanren/Goal.hs
@@ -34,8 +34,6 @@ import Kanren.Core
 import qualified Kanren.Core as Core
 import Kanren.Stream
 
-import Debug.Trace
-
 infix 4 ===, =/=
 infixr 3 `conj`
 infixr 2 `disj`
@@ -126,11 +124,11 @@ instance Alternative Goal where
 run :: (Fresh v) => (v -> Goal ()) -> [v]
 run f = Foldable.toList solutions
  where
-  states = trace "states" $ flip runGoal Core.empty $ do
+  states = flip runGoal Core.empty $ do
     vars <- fresh
     f vars
     pure vars
-  solutions = trace "solutions" $ fmap (uncurry resolve) states
+  solutions = fmap (uncurry resolve) states
 
 -- | A goal that always succeeds.
 --
@@ -314,7 +312,7 @@ fresh' = Goal (pure . makeVariable)
 
 instance (Logical a) => Fresh (Term a) where
   fresh = fresh'
-  resolve = trace "resolve" walk'
+  resolve = walk'
 
 instance (Logical a, Fresh v) => Fresh (Term a, v) where
   fresh = do

--- a/src/Kanren/Stream.hs
+++ b/src/Kanren/Stream.hs
@@ -7,8 +7,8 @@ import           Prelude hiding (take)
 
 data Stream a
   = Done
-  | Only a
-  | Yield a (Stream a)
+  | Only !a
+  | Yield !a (Stream a)
   | Await (Stream a)
   deriving (Functor, Foldable)
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2023-01-01.yaml
-resolver: lts-22.21
+resolver: nightly-2024-08-02
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -29,7 +29,7 @@ resolver: lts-22.21
 #   - auto-update
 #   - wai
 packages:
-- .
+  - .
 # Dependency packages to be pulled from upstream that are not in the resolver.
 # These entries can reference officially published versions as well as
 # forks / in-progress versions pinned to a git hash. For example:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: b146f371d1a90abbd2aeae1da10f776951046be50eae55a6fe93548a74fcc0dd
-    size: 713338
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/21.yaml
-  original: lts-22.21
+    sha256: 2b63732cfb5782292320fdba3920b71a2144d1265018f0312cb35b0ce04e78f5
+    size: 656849
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2024/8/2.yaml
+  original: nightly-2024-08-02


### PR DESCRIPTION
We implement [`set-var-val!` optimization](https://github.com/michaelballantyne/faster-minikanren/blob/ed6f72a42d9708d4c9ae8cdc874d07119a3e8711/README.md#set-var-val) from `faster-minikanren`, relying on `IORef` and `unsafePerformIO` to keep `Stream` effectless. 

Unfortunately, currently it does not seem to speed things up and instead we see a minor slowdown.

## Why `IORef`?

Our experiments in `strefs`, `strefs-logict`, and `strefs-streamly` branches show that using a version of streams with effects slows them down significantly. It is possible that we did not use them correctly, of course, but for the miniKanren implementation it appears that we want best of both pull- and push-based streams. One kind is necessary for binding, and another kind for interleaving. Introducing effects seems to mess with performance of either of these significantly (probably not allowing some optimizations?).

So, here we try to sneak in `IORef`s that are hidden in the `Kanren.Core` and inaccessible by the end user, so that should be sufficiently safe to use with `unsafePerformIO`.